### PR TITLE
fix: correct the readme example

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,11 @@ Conventions for Rust services
 
 ## Tracing (and logging)
 
+```
+cargo add service_conventions
+```
+
 ```rust
 
-service_conventions::tracing::setup();
+service_conventions::tracing::setup(tracing::Level::DEBUG);
 ```


### PR DESCRIPTION
Readme did not have the install instructions
Fix example