### PR TITLE
chore: Update to use repo token

### DIFF
--- a/.github/workflows/push_main.yml
+++ b/.github/workflows/push_main.yml
@@ -1,11 +1,9 @@
-name: Release
+name: Main Branch Deploy
 
 on:
   push:
     branches:
       - main
-    tags:
-      - "*"
 
 permissions:
   pull-requests: write
@@ -20,7 +18,7 @@ jobs:
     uses: "philipcristiano/workflows/.github/workflows/rust_release.yml@main"
     needs: [flake, rust]
     secrets:
-      WF_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      WF_GITHUB_TOKEN: ${{ secrets.REPO_TOKEN }}
       CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
 
   flake:


### PR DESCRIPTION
Use a repo specific PAT that will allow downstream workflow triggering. 

Useful for release-plz version PRs to run tests/checks instead of having to close/open a PR