### PR TITLE
chore: release v0.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,17 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.0.2](https://github.com/philipcristiano/rust_service_conventions/compare/v0.0.1...v0.0.2) - 2024-01-22
+
+### Fixed
+- correct the readme example ([#4](https://github.com/philipcristiano/rust_service_conventions/pull/4))
+
+### Other
+- Use explicit Actions token
+- Update to use repo token
+- *(deps)* Bump agenthunt/conventional-commit-checker-action

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "service_conventions"
-version = "0.0.1"
+version = "0.0.2"
 edition = "2021"
 description = "Conventions for services"
 license = "Apache-2.0"


### PR DESCRIPTION
## 🤖 New release
* `service_conventions`: 0.0.1 -> 0.0.2 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.0.2](https://github.com/philipcristiano/rust_service_conventions/compare/v0.0.1...v0.0.2) - 2024-01-22

### Fixed
- correct the readme example ([#4](https://github.com/philipcristiano/rust_service_conventions/pull/4))

### Other
- Use explicit Actions token
- Update to use repo token
- *(deps)* Bump agenthunt/conventional-commit-checker-action
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).