### PR TITLE
chore: release v0.0.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.3](https://github.com/philipcristiano/rust_service_conventions/compare/v0.0.2...v0.0.3) - 2024-03-09
+
+### Other
+- Add missing deps for oidc
+
 ## [0.0.2](https://github.com/philipcristiano/rust_service_conventions/compare/v0.0.1...v0.0.2) - 2024-03-09
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "service_conventions"
-version = "0.0.2"
+version = "0.0.3"
 edition = "2021"
 description = "Conventions for services"
 license = "Apache-2.0"


### PR DESCRIPTION
## 🤖 New release
* `service_conventions`: 0.0.2 -> 0.0.3 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.0.3](https://github.com/philipcristiano/rust_service_conventions/compare/v0.0.2...v0.0.3) - 2024-03-09

### Other
- Add missing deps for oidc
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).