### PR TITLE
chore: release v0.0.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.5](https://github.com/philipcristiano/rust_service_conventions/compare/v0.0.4...v0.0.5) - 2024-03-12
+
+### Other
+- redirect after auth
+- oidc-user
+- Merge pull request [#16](https://github.com/philipcristiano/rust_service_conventions/pull/16) from philipcristiano/release-plz-2024-03-09T21-41-29Z
+
 ## [0.0.4](https://github.com/philipcristiano/rust_service_conventions/compare/v0.0.3...v0.0.4) - 2024-03-09
 
 ### Other

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "service_conventions"
-version = "0.0.4"
+version = "0.0.5"
 edition = "2021"
 description = "Conventions for services"
 license = "Apache-2.0"


### PR DESCRIPTION
## 🤖 New release
* `service_conventions`: 0.0.4 -> 0.0.5 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.0.5](https://github.com/philipcristiano/rust_service_conventions/compare/v0.0.4...v0.0.5) - 2024-03-12

### Other
- redirect after auth
- oidc-user
- Merge pull request [#16](https://github.com/philipcristiano/rust_service_conventions/pull/16) from philipcristiano/release-plz-2024-03-09T21-41-29Z
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).