### PR TITLE
chore: release v0.0.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.6](https://github.com/philipcristiano/rust_service_conventions/compare/v0.0.5...v0.0.6) - 2024-03-16
+
+### Added
+- oidc: Remove state from router setup
+
+### Other
+- Include lint/fixers
+
 ## [0.0.5](https://github.com/philipcristiano/rust_service_conventions/compare/v0.0.4...v0.0.5) - 2024-03-12
 
 ### Other

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "service_conventions"
-version = "0.0.5"
+version = "0.0.6"
 edition = "2021"
 description = "Conventions for services"
 license = "Apache-2.0"


### PR DESCRIPTION
## 🤖 New release
* `service_conventions`: 0.0.5 -> 0.0.6 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.0.6](https://github.com/philipcristiano/rust_service_conventions/compare/v0.0.5...v0.0.6) - 2024-03-16

### Added
- oidc: Remove state from router setup

### Other
- Include lint/fixers
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).