### PR TITLE
feat: oidc: Remove state from router setup

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ async-trait = {version = "0.1", optional = true}
 
 [features]
 all = ["tracing", "oidc"]
-default = ["tracing"]
+default = ["tracing", "oidc"]
 tracing = ["dep:opentelemetry", "dep:opentelemetry-otlp", "dep:opentelemetry-semantic-conventions", "dep:tracing-subscriber", "dep:tracing", "dep:tracing-opentelemetry", "dep:opentelemetry_sdk"]
 oidc = ["dep:anyhow", "dep:once_cell", "dep:openidconnect", "dep:serde", "dep:serde_json", "dep:maud", "dep:axum", "dep:tower-cookies", "dep:url", "dep:email_address", "dep:http", "dep:async-trait", "dep:axum-core"]
 

--- a/src/oidc.rs
+++ b/src/oidc.rs
@@ -238,9 +238,8 @@ pub fn router(auth_config: AuthConfig) -> axum::Router<AuthConfig> {
     let my_key: &[u8] = &[0; 64]; // Your real key must be cryptographically random
     KEY.set(Key::from(my_key)).ok();
     let r = Router::new()
-        .route("/login", get(oidc_login).with_state(auth_config.clone()))
-        .route("/login_auth", get(login_auth))
-        .with_state(auth_config.clone());
+        .route("/login", get(oidc_login))
+        .route("/login_auth", get(login_auth));
     r
 }
 const COOKIE_NAME: &str = "auth_flow";


### PR DESCRIPTION
axum docs recommend not including state in the router and having the nesting-router handle it