### PR TITLE
chore: release v0.0.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.8](https://github.com/philipcristiano/rust_service_conventions/compare/v0.0.7...v0.0.8) - 2024-03-19
+
+### Added
+- [**breaking**] oidc: Return scopes/groups
+
 ## [0.0.7](https://github.com/philipcristiano/rust_service_conventions/compare/v0.0.6...v0.0.7) - 2024-03-19
 
 ### Fixed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "service_conventions"
-version = "0.0.7"
+version = "0.0.8"
 edition = "2021"
 description = "Conventions for services"
 license = "Apache-2.0"


### PR DESCRIPTION
## 🤖 New release
* `service_conventions`: 0.0.7 -> 0.0.8 (⚠️ API breaking changes)

### ⚠️ `service_conventions` breaking changes

```
--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.29.1/src/lints/constructible_struct_adds_field.ron

Failed in:
  field OIDCUser.groups in /tmp/.tmpOlyo3r/rust_service_conventions/src/oidc.rs:47
  field OIDCUser.scopes in /tmp/.tmpOlyo3r/rust_service_conventions/src/oidc.rs:48
  field AuthConfig.oidc_config in /tmp/.tmpOlyo3r/rust_service_conventions/src/oidc.rs:37
  field AuthConfig.scopes in /tmp/.tmpOlyo3r/rust_service_conventions/src/oidc.rs:39

--- failure function_parameter_count_changed: pub fn parameter count changed ---

Description:
A publicly-visible function now takes a different number of parameters.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#fn-change-arity
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.29.1/src/lints/function_parameter_count_changed.ron

Failed in:
  service_conventions::oidc::get_auth_url now takes 2 parameters instead of 1, in /tmp/.tmpOlyo3r/rust_service_conventions/src/oidc.rs:155

--- failure struct_pub_field_missing: pub struct's pub field removed or renamed ---

Description:
A publicly-visible struct has at least one public field that is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.29.1/src/lints/struct_pub_field_missing.ron

Failed in:
  field group_claims of struct OIDCUser, previously in file /tmp/.tmp31dRAA/service_conventions/src/oidc.rs:41
  field issuer_url of struct AuthConfig, previously in file /tmp/.tmp31dRAA/service_conventions/src/oidc.rs:29
  field redirect_url of struct AuthConfig, previously in file /tmp/.tmp31dRAA/service_conventions/src/oidc.rs:30
  field client_id of struct AuthConfig, previously in file /tmp/.tmp31dRAA/service_conventions/src/oidc.rs:31
  field client_secret of struct AuthConfig, previously in file /tmp/.tmp31dRAA/service_conventions/src/oidc.rs:32
```

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.0.8](https://github.com/philipcristiano/rust_service_conventions/compare/v0.0.7...v0.0.8) - 2024-03-19

### Added
- [**breaking**] oidc: Return scopes/groups
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).