### PR TITLE
chore: release v0.0.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.9](https://github.com/philipcristiano/rust_service_conventions/compare/v0.0.8...v0.0.9) - 2024-03-31
+
+### Fixed
+- tracing: Include https things for reqwest
+- *(deps)* update rust crate axum to 0.7.5
+- *(deps)* update rust crate openidconnect to 3.5.0
+
+### Other
+- Switch to renovate
+
 ## [0.0.8](https://github.com/philipcristiano/rust_service_conventions/compare/v0.0.7...v0.0.8) - 2024-03-19
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "service_conventions"
-version = "0.0.8"
+version = "0.0.9"
 edition = "2021"
 description = "Conventions for services"
 license = "Apache-2.0"


### PR DESCRIPTION
## 🤖 New release
* `service_conventions`: 0.0.8 -> 0.0.9 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.0.9](https://github.com/philipcristiano/rust_service_conventions/compare/v0.0.8...v0.0.9) - 2024-03-31

### Fixed
- tracing: Include https things for reqwest
- *(deps)* update rust crate axum to 0.7.5
- *(deps)* update rust crate openidconnect to 3.5.0

### Other
- Switch to renovate
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).