### PR TITLE
tracing: Use tls feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ license = "Apache-2.0"
 
 [dependencies]
 opentelemetry = { version = "0.22.0", features = [], optional = true }
-opentelemetry-otlp = { version = "0.15.0", features = ["trace", "grpc-tonic", "http-proto", "reqwest-rustls"], optional = true }
+opentelemetry-otlp = { version = "0.15.0", features = ["trace", "grpc-tonic", "http-proto", "reqwest-rustls", "tls"], optional = true }
 opentelemetry-semantic-conventions = { version = "0.14.0", optional = true}
 opentelemetry_sdk = { version = "0.22.1", features = ["rt-tokio"], optional = true }
 


### PR DESCRIPTION
Otherwise the GRPC channel won't be made with tls

Maybe solves the problem I've had of https endpoint connection being http