### PR TITLE
chore: release v0.0.12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.12](https://github.com/philipcristiano/rust_service_conventions/compare/v0.0.11...v0.0.12) - 2024-03-31
+
+### Fixed
+- tracing: Use defaults for resources
+
 ## [0.0.11](https://github.com/philipcristiano/rust_service_conventions/compare/v0.0.10...v0.0.11) - 2024-03-31
 
 ### Other

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "service_conventions"
-version = "0.0.11"
+version = "0.0.12"
 edition = "2021"
 description = "Conventions for services"
 license = "Apache-2.0"


### PR DESCRIPTION
## 🤖 New release
* `service_conventions`: 0.0.11 -> 0.0.12 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.0.12](https://github.com/philipcristiano/rust_service_conventions/compare/v0.0.11...v0.0.12) - 2024-03-31

### Fixed
- tracing: Use defaults for resources
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).