### PR TITLE
chore: release v0.0.14

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.14](https://github.com/philipcristiano/rust_service_conventions/compare/v0.0.13...v0.0.14) - 2024-04-03
+
+### Other
+- Revert "fix: tracing: Set tracing level to tracing"
+
 ## [0.0.13](https://github.com/philipcristiano/rust_service_conventions/compare/v0.0.12...v0.0.13) - 2024-04-03
 
 ### Fixed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "service_conventions"
-version = "0.0.13"
+version = "0.0.14"
 edition = "2021"
 description = "Conventions for services"
 license = "Apache-2.0"


### PR DESCRIPTION
## 🤖 New release
* `service_conventions`: 0.0.13 -> 0.0.14 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.0.14](https://github.com/philipcristiano/rust_service_conventions/compare/v0.0.13...v0.0.14) - 2024-04-03

### Other
- Revert "fix: tracing: Set tracing level to tracing"
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).