### PR TITLE
chore: release v0.0.15

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.15](https://github.com/philipcristiano/rust_service_conventions/compare/v0.0.14...v0.0.15) - 2024-04-16
+
+### Fixed
+- fix!(oidc): Set key via config
+
+### Other
+- *(deps)* lock file maintenance
+- *(deps)* lock file maintenance
+- *(deps)* lock file maintenance
+
 ## [0.0.14](https://github.com/philipcristiano/rust_service_conventions/compare/v0.0.13...v0.0.14) - 2024-04-03
 
 ### Other

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "service_conventions"
-version = "0.0.14"
+version = "0.0.15"
 edition = "2021"
 description = "Conventions for services"
 license = "Apache-2.0"


### PR DESCRIPTION
## 🤖 New release
* `service_conventions`: 0.0.14 -> 0.0.15 (⚠️ API breaking changes)

### ⚠️ `service_conventions` breaking changes

```
--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.30.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field OIDCConfig.key in /tmp/.tmpmQ8OkP/rust_service_conventions/src/oidc.rs:34
```

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.0.15](https://github.com/philipcristiano/rust_service_conventions/compare/v0.0.14...v0.0.15) - 2024-04-16

### Fixed
- fix!(oidc): Set key via config

### Other
- *(deps)* lock file maintenance
- *(deps)* lock file maintenance
- *(deps)* lock file maintenance
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).