### PR TITLE
fix!(oidc): Set key via config

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,10 +31,11 @@ email_address = {version = "0.2.4", optional = true}
 http = {version = "1.1.0", optional = true}
 axum-core =   {version = "0.4", optional = true}
 async-trait = {version = "0.1", optional = true}
+redacted = {version = "0.2.0", optional = true}
 
 [features]
 all = ["tracing", "oidc"]
 default = ["tracing", "oidc"]
 tracing = ["dep:opentelemetry", "dep:opentelemetry-otlp", "dep:opentelemetry-semantic-conventions", "dep:tracing-subscriber", "dep:tracing", "dep:tracing-opentelemetry", "dep:opentelemetry_sdk"]
-oidc = ["dep:anyhow", "dep:once_cell", "dep:openidconnect", "dep:serde", "dep:serde_json", "dep:maud", "dep:axum", "dep:tower-cookies", "dep:url", "dep:email_address", "dep:http", "dep:async-trait", "dep:axum-core"]
+oidc = ["dep:anyhow", "dep:once_cell", "dep:openidconnect", "dep:serde", "dep:serde_json", "dep:maud", "dep:axum", "dep:tower-cookies", "dep:url", "dep:email_address", "dep:http", "dep:async-trait", "dep:axum-core", "dep:redacted"]
 


### PR DESCRIPTION
Instead of using the same hardcoded key.

Breaking change, this value must be set in the config of services