### PR TITLE
chore: release v0.0.16

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.16](https://github.com/philipcristiano/rust_service_conventions/compare/v0.0.15...v0.0.16) - 2024-04-16
+
+### Other
+- Include cargo repo url
+
 ## [0.0.15](https://github.com/philipcristiano/rust_service_conventions/compare/v0.0.14...v0.0.15) - 2024-04-16
 
 ### Fixed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "service_conventions"
-version = "0.0.15"
+version = "0.0.16"
 edition = "2021"
 description = "Conventions for services"
 license = "Apache-2.0"


### PR DESCRIPTION
## 🤖 New release
* `service_conventions`: 0.0.15 -> 0.0.16 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.0.16](https://github.com/philipcristiano/rust_service_conventions/compare/v0.0.15...v0.0.16) - 2024-04-16

### Other
- Include cargo repo url
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).