### PR TITLE
feat: Support W3C tracecontext

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ serde_json = {version = "1.0.116", optional = true}
 maud = { version="0.26.0", features = ["axum"], optional = true }
 axum = { version = "0.7.5", optional = true}
 tower-cookies = { version = "0.10.0", features = ["signed", "private", "axum-core"], optional = true}
+tower-http = { version = "0.5.2", features = ["tracing", "trace", "compression-gzip"], optional = true }
 
 url = { version = "2.5.0", optional = true }
 email_address = {version = "0.2.4", optional = true}
@@ -35,8 +36,8 @@ async-trait = {version = "0.1.80", optional = true}
 redacted = {version = "0.2.0", optional = true}
 
 [features]
-all = ["tracing", "oidc"]
-default = ["tracing", "oidc"]
+all = ["tracing", "oidc", "tracing-http"]
+default = ["tracing", "oidc", "tracing-http"]
 tracing = ["dep:opentelemetry", "dep:opentelemetry-otlp", "dep:opentelemetry-semantic-conventions", "dep:tracing-subscriber", "dep:tracing", "dep:tracing-opentelemetry", "dep:opentelemetry_sdk"]
 oidc = ["dep:anyhow", "dep:once_cell", "dep:openidconnect", "dep:serde", "dep:serde_json", "dep:maud", "dep:axum", "dep:tower-cookies", "dep:url", "dep:email_address", "dep:http", "dep:async-trait", "dep:axum-core", "dep:redacted"]
-
+tracing-http = ["tracing", "dep:http", "dep:tower-http"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,14 +9,14 @@ repository = "https://github.com/philipcristiano/rust_service_conventions"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-opentelemetry = { version = "0.23.0", features = [], optional = true }
-opentelemetry-otlp = { version = "0.15.0", features = ["trace", "grpc-tonic", "http-proto", "reqwest-rustls", "tls", "tls-roots"], optional = true }
+opentelemetry = { version = "0.23.0", optional = true }
+opentelemetry-otlp = { version = "0.16.0", features = ["trace", "grpc-tonic", "http-proto", "reqwest-rustls", "tls", "tls-roots"], optional = true }
 opentelemetry-semantic-conventions = { version = "0.15.0", optional = true}
-opentelemetry_sdk = { version = "0.22.1", features = ["rt-tokio"], optional = true }
+opentelemetry_sdk = { version = "0.23.0", features = ["rt-tokio"], optional = true }
 
 tracing-subscriber = { version = "0.3.18", features = ["fmt", "json", "env-filter", "std", "registry"], optional = true }
 tracing = { version = "0.1.40", optional = true}
-tracing-opentelemetry = { version = "0.23.0", optional = true}
+tracing-opentelemetry = { version = "0.24.0", optional = true}
 
 anyhow = {version = "1.0.82", optional = true}
 once_cell = { version = "1.19.0", optional = true}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,3 +3,6 @@ pub mod oidc;
 
 #[cfg(feature = "tracing")]
 pub mod tracing;
+
+#[cfg(feature = "tracing-http")]
+pub mod tracing_http;

--- a/src/tracing.rs
+++ b/src/tracing.rs
@@ -9,6 +9,10 @@ use tracing_opentelemetry::OpenTelemetryLayer;
 use tracing_subscriber::prelude::__tracing_subscriber_SubscriberExt;
 
 pub fn setup(level: Level) {
+    use opentelemetry::global;
+    use opentelemetry_sdk::propagation::TraceContextPropagator;
+    global::set_text_map_propagator(TraceContextPropagator::new());
+
     let subscriber = registry()
         .with(
             OpenTelemetryLayer::new(init_tracer())

--- a/src/tracing_http.rs
+++ b/src/tracing_http.rs
@@ -1,0 +1,65 @@
+use tower_http::classify::{ServerErrorsAsFailures, SharedClassifier};
+use tower_http::trace::{self, TraceLayer};
+use tracing::Level;
+
+pub type TracingLayer = TraceLayer<SharedClassifier<ServerErrorsAsFailures>>;
+pub fn trace_layer(
+    level: Level,
+) -> TraceLayer<SharedClassifier<ServerErrorsAsFailures>, MakeSpan, OnRequest> {
+    TraceLayer::new_for_http()
+        .make_span_with(MakeSpan::new())
+        .on_request(OnRequest::new())
+        .on_response(trace::DefaultOnResponse::new().level(level))
+}
+
+#[derive(Clone, Debug)]
+pub struct MakeSpan {}
+
+impl MakeSpan {
+    fn new() -> Self {
+        MakeSpan {}
+    }
+}
+
+impl<B> tower_http::trace::MakeSpan<B> for MakeSpan {
+    fn make_span(&mut self, request: &http::Request<B>) -> tracing::Span {
+        tracing::span!(
+            tracing::Level::INFO,
+            "request",
+            method = %request.method(),
+            uri = %request.uri(),
+            version = ?request.version(),
+            "otel.name" = tracing::field::Empty,
+
+        )
+    }
+}
+#[derive(Clone, Debug)]
+pub struct OnRequest {}
+
+impl OnRequest {
+    fn new() -> Self {
+        OnRequest {}
+    }
+}
+
+impl<B> tower_http::trace::OnRequest<B> for OnRequest {
+    fn on_request(&mut self, request: &http::request::Request<B>, s: &tracing::Span) {
+        use opentelemetry::global;
+        use tracing_opentelemetry::OpenTelemetrySpanExt;
+        let axum_headers = request.headers();
+        let maybe_traceparent = axum_headers.get("traceparent");
+        let name = format!("{} {}", request.method(), request.uri().path());
+        s.record("otel.name", name.clone());
+        if let Some(traceparent) = maybe_traceparent {
+            let mut hm = std::collections::HashMap::new();
+            hm.insert(
+                "traceparent".to_string(),
+                traceparent.to_str().unwrap().to_string(),
+            );
+            let parent_context =
+                global::get_text_map_propagator(|propagator| propagator.extract(&hm));
+            s.set_parent(parent_context.clone());
+        }
+    }
+}


### PR DESCRIPTION
This allows setting the parentSpanId value on the outgoing OTel tracing request. (Not reqwest or similar API calls)

The TraceProvider handles reading state from the OTel specific backends in the library. Without this it seems the value is just lost