### PR TITLE
chore: release v0.0.18

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.18](https://github.com/philipcristiano/rust_service_conventions/compare/v0.0.17...v0.0.18) - 2024-07-15
+
+### Other
+- Include function for getting context headermap
+- *(deps)* lock file maintenance
+
 ## [0.0.17](https://github.com/philipcristiano/rust_service_conventions/compare/v0.0.16...v0.0.17) - 2024-07-10
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "service_conventions"
-version = "0.0.17"
+version = "0.0.18"
 edition = "2021"
 description = "Conventions for services"
 license = "Apache-2.0"


### PR DESCRIPTION
## 🤖 New release
* `service_conventions`: 0.0.17 -> 0.0.18

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.0.18](https://github.com/philipcristiano/rust_service_conventions/compare/v0.0.17...v0.0.18) - 2024-07-15

### Other
- Include function for getting context headermap
- *(deps)* lock file maintenance
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).