### PR TITLE
chore: release v0.0.20

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.20](https://github.com/philipcristiano/rust_service_conventions/compare/v0.0.19...v0.0.20) - 2024-08-27
+
+### Fixed
+- oidc: Set cookie age
+
+### Other
+- *(deps)* lock file maintenance
+- *(deps)* lock file maintenance
+- *(deps)* lock file maintenance
+- *(deps)* lock file maintenance
+
 ## [0.0.19](https://github.com/philipcristiano/rust_service_conventions/compare/v0.0.18...v0.0.19) - 2024-08-03
 
 ### Fixed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "service_conventions"
-version = "0.0.19"
+version = "0.0.20"
 edition = "2021"
 description = "Conventions for services"
 license = "Apache-2.0"


### PR DESCRIPTION
## 🤖 New release
* `service_conventions`: 0.0.19 -> 0.0.20

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.0.20](https://github.com/philipcristiano/rust_service_conventions/compare/v0.0.19...v0.0.20) - 2024-08-27

### Fixed
- oidc: Set cookie age

### Other
- *(deps)* lock file maintenance
- *(deps)* lock file maintenance
- *(deps)* lock file maintenance
- *(deps)* lock file maintenance
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).