### PR TITLE
fix: oidc: Set cookie age

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,10 +34,11 @@ http = {version = "1.1.0", optional = true}
 axum-core =   {version = "0.4.3", optional = true}
 async-trait = {version = "0.1.80", optional = true}
 redacted = {version = "0.2.0", optional = true}
+chrono = {version = "0.4.38", optional = true}
 
 [features]
 all = ["tracing", "oidc", "tracing-http"]
 default = ["tracing", "oidc", "tracing-http"]
 tracing = ["dep:opentelemetry", "dep:opentelemetry-otlp", "dep:opentelemetry-semantic-conventions", "dep:tracing-subscriber", "dep:tracing", "dep:tracing-opentelemetry", "dep:opentelemetry_sdk"]
-oidc = ["dep:anyhow", "dep:once_cell", "dep:openidconnect", "dep:serde", "dep:serde_json", "dep:maud", "dep:axum", "dep:tower-cookies", "dep:url", "dep:email_address", "dep:http", "dep:async-trait", "dep:axum-core", "dep:redacted"]
+oidc = ["dep:anyhow", "dep:chrono", "dep:once_cell", "dep:openidconnect", "dep:serde", "dep:serde_json", "dep:maud", "dep:axum", "dep:tower-cookies", "dep:url", "dep:email_address", "dep:http", "dep:async-trait", "dep:axum-core", "dep:redacted"]
 tracing-http = ["tracing", "dep:http", "dep:tower-http"]


### PR DESCRIPTION
Use the expiration from the OIDC authorization to set the cookie max-age

So that session age can be set from the auth system