### PR TITLE
chore: release v0.0.21

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.21](https://github.com/philipcristiano/rust_service_conventions/compare/v0.0.20...v0.0.21) - 2024-09-20
+
+### Fixed
+
+- *(deps)* update rust crate tracing-opentelemetry to 0.26.0
+- Tracing export over TLS
+- Include TLS features for tracing
+- *(deps)* update rust crate tower-http to 0.6.0
+
+### Other
+
+- Merge remote-tracking branch 'origin/renovate/tracing-opentelemetry-0.x' into tracing-merge
+- *(deps)* lock file maintenance
+- *(deps)* lock file maintenance
+- *(deps)* lock file maintenance
+- *(deps)* lock file maintenance
+
 ## [0.0.20](https://github.com/philipcristiano/rust_service_conventions/compare/v0.0.19...v0.0.20) - 2024-08-27
 
 ### Fixed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "service_conventions"
-version = "0.0.20"
+version = "0.0.21"
 edition = "2021"
 description = "Conventions for services"
 license = "Apache-2.0"


### PR DESCRIPTION
## 🤖 New release
* `service_conventions`: 0.0.20 -> 0.0.21 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.0.21](https://github.com/philipcristiano/rust_service_conventions/compare/v0.0.20...v0.0.21) - 2024-09-20

### Fixed

- *(deps)* update rust crate tracing-opentelemetry to 0.26.0
- Tracing export over TLS
- Include TLS features for tracing
- *(deps)* update rust crate tower-http to 0.6.0

### Other

- Merge remote-tracking branch 'origin/renovate/tracing-opentelemetry-0.x' into tracing-merge
- *(deps)* lock file maintenance
- *(deps)* lock file maintenance
- *(deps)* lock file maintenance
- *(deps)* lock file maintenance
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).