### PR TITLE
fix: Tracing export over TLS

### DIFF
--- a/src/tracing.rs
+++ b/src/tracing.rs
@@ -32,7 +32,9 @@ fn init_tracer() -> Tracer {
     use opentelemetry::trace::TracerProvider as _;
     use opentelemetry_otlp::TonicExporterBuilder;
     use opentelemetry_sdk::trace::TracerProvider;
+    let tls_config = tonic::transport::ClientTlsConfig::new().with_native_roots();
     let exporter = TonicExporterBuilder::default()
+        .with_tls_config(tls_config)
         .build_span_exporter()
         .expect("Init");
     let provider = TracerProvider::builder()


### PR DESCRIPTION
Tonic changed defaults that broke "how things worked" with otel

https://github.com/open-telemetry/opentelemetry-rust/issues/2008

Now be more explicit to enable the previous behavior