### PR TITLE
chore: release v0.0.22

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.22](https://github.com/philipcristiano/rust_service_conventions/compare/v0.0.21...v0.0.22) - 2024-10-03
+
+### Fixed
+
+- oidc: Wrap oidc cookie errors with enum
+- Secure cookies
+
+### Other
+
+- *(deps)* lock file maintenance
+- *(deps)* lock file maintenance
+
 ## [0.0.21](https://github.com/philipcristiano/rust_service_conventions/compare/v0.0.20...v0.0.21) - 2024-09-20
 
 ### Fixed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "service_conventions"
-version = "0.0.21"
+version = "0.0.22"
 edition = "2021"
 description = "Conventions for services"
 license = "Apache-2.0"


### PR DESCRIPTION
## 🤖 New release
* `service_conventions`: 0.0.21 -> 0.0.22 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.0.22](https://github.com/philipcristiano/rust_service_conventions/compare/v0.0.21...v0.0.22) - 2024-10-03

### Fixed

- oidc: Wrap oidc cookie errors with enum
- Secure cookies

### Other

- *(deps)* lock file maintenance
- *(deps)* lock file maintenance
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).