### PR TITLE
fix: oidc: Wrap oidc cookie errors with enum

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,7 @@ axum-core =   {version = "0.4.3", optional = true}
 async-trait = {version = "0.1.80", optional = true}
 redacted = {version = "0.2.0", optional = true}
 chrono = {version = "0.4.38", optional = true}
+thiserror = "1.0.64"
 
 [features]
 all = ["tracing", "oidc", "tracing-http"]


### PR DESCRIPTION
So they can be extracted later on if needed