### PR TITLE
feat: Refresh user if cookie expires

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ openidconnect = {version = "3.5.0", optional = true, features = ["accept-rfc3339
 serde = { version = "1.0.200", features = ["derive"], optional = true }
 serde_json = {version = "1.0.116", optional = true}
 maud = { version="0.26.0", features = ["axum"], optional = true }
-axum = { version = "0.7.5", optional = true}
+axum = { version = "0.7.5", optional = true, features = ["macros"]}
 tower-cookies = { version = "0.10.0", features = ["signed", "private", "axum-core"], optional = true}
 tower-http = { version = "0.6.0", features = ["tracing", "trace", "compression-gzip"], optional = true }
 


### PR DESCRIPTION
If there is a refresh token for the OIDC user then store that and use it for refreshing the user if possible.