### PR TITLE
chore: release v0.0.25

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.25](https://github.com/philipcristiano/rust_service_conventions/compare/v0.0.24...v0.0.25) - 2025-01-06
+
+### Fixed
+
+- *(deps)* update rust crate axum-core to 0.5.0
+
+### Other
+
+- Update for 0.8 axum
+- Merge remote-tracking branch 'origin/renovate/tower-cookies-0.x' into renovate/axum-0.x
+- Merge remote-tracking branch 'origin/renovate/axum-core-0.x' into renovate/axum-0.x
+- *(deps)* lock file maintenance (#165)
+- *(deps)* lock file maintenance (#164)
+- *(deps)* lock file maintenance (#160)
+- *(deps)* lock file maintenance (#159)
+- *(deps)* lock file maintenance (#158)
+- *(deps)* lock file maintenance (#157)
+- *(deps)* lock file maintenance (#156)
+- *(deps)* lock file maintenance (#155)
+- *(deps)* lock file maintenance (#154)
+- *(deps)* lock file maintenance (#152)
+
 ## [0.0.24](https://github.com/philipcristiano/rust_service_conventions/compare/v0.0.23...v0.0.24) - 2024-12-01
 
 ### Fixed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "service_conventions"
-version = "0.0.24"
+version = "0.0.25"
 edition = "2021"
 description = "Conventions for services"
 license = "Apache-2.0"


### PR DESCRIPTION
## 🤖 New release
* `service_conventions`: 0.0.24 -> 0.0.25 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.0.25](https://github.com/philipcristiano/rust_service_conventions/compare/v0.0.24...v0.0.25) - 2025-01-06

### Fixed

- *(deps)* update rust crate axum-core to 0.5.0

### Other

- Update for 0.8 axum
- Merge remote-tracking branch 'origin/renovate/tower-cookies-0.x' into renovate/axum-0.x
- Merge remote-tracking branch 'origin/renovate/axum-core-0.x' into renovate/axum-0.x
- *(deps)* lock file maintenance (#165)
- *(deps)* lock file maintenance (#164)
- *(deps)* lock file maintenance (#160)
- *(deps)* lock file maintenance (#159)
- *(deps)* lock file maintenance (#158)
- *(deps)* lock file maintenance (#157)
- *(deps)* lock file maintenance (#156)
- *(deps)* lock file maintenance (#155)
- *(deps)* lock file maintenance (#154)
- *(deps)* lock file maintenance (#152)
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).