### PR TITLE
chore: release v0.0.28

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.28](https://github.com/philipcristiano/rust_service_conventions/compare/v0.0.27...v0.0.28) - 2025-04-03
+
+### Fixed
+
+- *(deps)* update rust crate tonic to 0.13.0
+
+### Other
+
+- Update otel/tracing
+- Upgrade tracing-opentelemetry
+- Use mozilla TLS roots
+
 ## [0.0.27](https://github.com/philipcristiano/rust_service_conventions/compare/v0.0.26...v0.0.27) - 2025-03-31
 
 ### Fixed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "service_conventions"
-version = "0.0.27"
+version = "0.0.28"
 edition = "2021"
 description = "Conventions for services"
 license = "Apache-2.0"


### PR DESCRIPTION



## 🤖 New release

* `service_conventions`: 0.0.27 -> 0.0.28 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.0.28](https://github.com/philipcristiano/rust_service_conventions/compare/v0.0.27...v0.0.28) - 2025-04-03

### Fixed

- *(deps)* update rust crate tonic to 0.13.0

### Other

- Update otel/tracing
- Upgrade tracing-opentelemetry
- Use mozilla TLS roots
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).