### PR TITLE
chore: release v0.0.29

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.29](https://github.com/philipcristiano/rust_service_conventions/compare/v0.0.28...v0.0.29) - 2025-04-03
+
+### Other
+
+- Drop tonic version to match otel
+
 ## [0.0.28](https://github.com/philipcristiano/rust_service_conventions/compare/v0.0.27...v0.0.28) - 2025-04-03
 
 ### Fixed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "service_conventions"
-version = "0.0.28"
+version = "0.0.29"
 edition = "2021"
 description = "Conventions for services"
 license = "Apache-2.0"


### PR DESCRIPTION



## 🤖 New release

* `service_conventions`: 0.0.28 -> 0.0.29 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.0.29](https://github.com/philipcristiano/rust_service_conventions/compare/v0.0.28...v0.0.29) - 2025-04-03

### Other

- Drop tonic version to match otel
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).