### PR TITLE
chore: remove deprecated stub

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -21,7 +21,6 @@
                     extensions = [ "rust-src" "rustfmt" ];
                 })
                 rust-analyzer
-                darwin.apple_sdk.frameworks.Security # Should only be for darwin
             ];
           };
         }


### PR DESCRIPTION
darwin.apple_sdk_11_0 has been removed as it was a legacy compatibility stub; see <https://nixos.org/manual/nixpkgs/stable/#sec-darwin-legacy-frameworks> for migration instructions