### PR TITLE
chore: release v0.0.33

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.33](https://github.com/philipcristiano/rust_service_conventions/compare/v0.0.32...v0.0.33) - 2025-09-08
+
+### Other
+
+- *(deps)* lock file maintenance ([#225](https://github.com/philipcristiano/rust_service_conventions/pull/225))
+
 ## [0.0.32](https://github.com/philipcristiano/rust_service_conventions/compare/v0.0.31...v0.0.32) - 2025-08-27
 
 ### Fixed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "service_conventions"
-version = "0.0.32"
+version = "0.0.33"
 edition = "2021"
 description = "Conventions for services"
 license = "Apache-2.0"


### PR DESCRIPTION



## 🤖 New release

* `service_conventions`: 0.0.32 -> 0.0.33 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>



</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).